### PR TITLE
refactor: removed the `addQueryIfNotEmpty` method and integrated its …

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -49,10 +49,6 @@ func (h *HttpClient) AddParams(key string, value string) HttpIntegration {
 }
 
 func (h *HttpClient) AddQuery(key string, value string) HttpIntegration {
-	h.queries[key] = value
-	return h
-}
-func (h *HttpClient) AddQueryIfNoEmpty(key string, value string) HttpIntegration {
 	if len(value) > 0 {
 		h.queries[key] = value
 	}

--- a/http_integration.go
+++ b/http_integration.go
@@ -14,7 +14,6 @@ type HttpIntegration interface {
 	AddHeader(key string, value string) HttpIntegration
 	AddParams(key string, value string) HttpIntegration
 	AddQuery(key string, value string) HttpIntegration
-	AddQueryIfNoEmpty(key string, value string) HttpIntegration
 	Interceptor(interceptor http.RoundTripper) HttpIntegration
 	Body(body []byte) HttpIntegration
 	BodyJson(body any) HttpIntegration


### PR DESCRIPTION
This PR removes an additional method that did not add value to the query parameter if the parameter is empty. Instead, this logic has been integrated into the main method for improved efficiency and clarity."